### PR TITLE
updated REPL links to v2 due to new API

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -42,41 +42,41 @@
 ## Examples
 ### REPL
 #### Basics
-- [Hello World](https://svelte.technology/repl?version=2&example=hello-world)
-- [If Blocks](https://svelte.technology/repl?version=2&example=if-blocks)
-- [Each Blocks](https://svelte.technology/repl?version=2&example=each-blocks)
-- [Scoped Styles](https://svelte.technology/repl?version=2&example=scoped-styles)
+- [Hello World](https://svelte.technology/repl?version=2&demo=hello-world)
+- [If Blocks](https://svelte.technology/repl?version=2&demo=if-blocks)
+- [Each Blocks](https://svelte.technology/repl?version=2&demo=each-blocks)
+- [Scoped Styles](https://svelte.technology/repl?version=2&demo=scoped-styles)
 
 #### Two-way Bindings
-- [Text Input](https://svelte.technology/repl?version=&example=binding-input-text)
-- [Textarea](https://svelte.technology/repl?version=2&example=binding-textarea)
-- [Checkbox Input](https://svelte.technology/repl?version=2&example=binding-input-checkbox)
-- [Media Elements](https://svelte.technology/repl?version=2&example=binding-media-elements)
+- [Text Input](https://svelte.technology/repl?version=&demo=binding-input-text)
+- [Textarea](https://svelte.technology/repl?version=2&demo=binding-textarea)
+- [Checkbox Input](https://svelte.technology/repl?version=2&demo=binding-input-checkbox)
+- [Media Elements](https://svelte.technology/repl?version=2&demo=binding-media-elements)
 
 #### Nested Components
-- [Self References](https://svelte.technology/repl?version=2&example=self-references)
-- [Nested Components](https://svelte.technology/repl?version=2&example=nested-components)
+- [Self References](https://svelte.technology/repl?version=2&demo=self-references)
+- [Nested Components](https://svelte.technology/repl?version=2&demo=nested-components)
 
 #### Window Component
-- [Parallax](https://svelte.technology/repl?version=2&example=parallax)
+- [Parallax](https://svelte.technology/repl?version=2&demo=parallax)
 
 #### SVG
-- [Clock](https://svelte.technology/repl?version=2&example=svg-clock)
-- [Line/Area Chart](https://svelte.technology/repl?version=2&example=line-chart)
-- [Bar Chart](https://svelte.technology/repl?version=2&example=bar-chart)
-- [Scatterplot](https://svelte.technology/repl?version=2&example=scatterplot)
+- [Clock](https://svelte.technology/repl?version=2&demo=svg-clock)
+- [Line/Area Chart](https://svelte.technology/repl?version=2&demo=line-chart)
+- [Bar Chart](https://svelte.technology/repl?version=2&demo=bar-chart)
+- [Scatterplot](https://svelte.technology/repl?version=2&demo=scatterplot)
 
 #### Transitions (Experimental)
 - [Fade](https://svelte.technology/repl?version=2&demo=transitions-fade)
 - 
 
 #### GUIs
-- [Counter](https://svelte.technology/repl?version=2&example=7guis-counter)
-- [Temperature Converter](https://svelte.technology/repl?version=2&example=7guis-temperature)
-- [Flight Booker](https://svelte.technology/repl?version=2&example=7guis-flight-booker)
-- [Timer](https://svelte.technology/repl?version=2&example=7guis-timer)
-- [CRUD](https://svelte.technology/repl?version=2&example=7guis-crud)
-- [Circles](https://svelte.technology/repl?version=2&example=7guis-circles)
+- [Counter](https://svelte.technology/repl?version=2&demo=7guis-counter)
+- [Temperature Converter](https://svelte.technology/repl?version=2&demo=7guis-temperature)
+- [Flight Booker](https://svelte.technology/repl?version=2&demo=7guis-flight-booker)
+- [Timer](https://svelte.technology/repl?version=2&demo=7guis-timer)
+- [CRUD](https://svelte.technology/repl?version=2&demo=7guis-crud)
+- [Circles](https://svelte.technology/repl?version=2&demo=7guis-circles)
 
 ### Apps
 - [Svelte HN](https://github.com/sveltejs/svelte-hackernews) - [An Hacker News clone](https://svelte-hn.now.sh) that _“is designed to test Svelte's ideas and see if there are any essential features that we're missing, and to act as an example for people looking to build their own Svelte apps.”_

--- a/readme.md
+++ b/readme.md
@@ -42,40 +42,41 @@
 ## Examples
 ### REPL
 #### Basics
-- [Hello World](https://svelte.technology/repl?version=1&example=hello-world)
-- [If Blocks](https://svelte.technology/repl?version=1&example=if-blocks)
-- [Each Blocks](https://svelte.technology/repl?version=1&example=each-blocks)
-- [Scoped Styles](https://svelte.technology/repl?version=1&example=scoped-styles)
+- [Hello World](https://svelte.technology/repl?version=2&example=hello-world)
+- [If Blocks](https://svelte.technology/repl?version=2&example=if-blocks)
+- [Each Blocks](https://svelte.technology/repl?version=2&example=each-blocks)
+- [Scoped Styles](https://svelte.technology/repl?version=2&example=scoped-styles)
 
 #### Two-way Bindings
-- [Text Input](https://svelte.technology/repl?version=1&example=binding-input-text)
-- [Textarea](https://svelte.technology/repl?version=1&example=binding-textarea)
-- [Checkbox Input](https://svelte.technology/repl?version=1&example=binding-input-checkbox)
-- [Media Elements](https://svelte.technology/repl?version=1&example=binding-media-elements)
+- [Text Input](https://svelte.technology/repl?version=&example=binding-input-text)
+- [Textarea](https://svelte.technology/repl?version=2&example=binding-textarea)
+- [Checkbox Input](https://svelte.technology/repl?version=2&example=binding-input-checkbox)
+- [Media Elements](https://svelte.technology/repl?version=2&example=binding-media-elements)
 
 #### Nested Components
-- [Self References](https://svelte.technology/repl?version=1&example=self-references)
-- [Nested Components](https://svelte.technology/repl?version=1&example=nested-components)
+- [Self References](https://svelte.technology/repl?version=2&example=self-references)
+- [Nested Components](https://svelte.technology/repl?version=2&example=nested-components)
 
 #### Window Component
-- [Parallax](https://svelte.technology/repl?version=1&example=parallax)
+- [Parallax](https://svelte.technology/repl?version=2&example=parallax)
 
 #### SVG
-- [Clock](https://svelte.technology/repl?version=1&example=svg-clock)
-- [Line/Area Chart](https://svelte.technology/repl?version=1&example=line-chart)
-- [Bar Chart](https://svelte.technology/repl?version=1&example=bar-chart)
-- [Scatterplot](https://svelte.technology/repl?version=1&example=scatterplot)
+- [Clock](https://svelte.technology/repl?version=2&example=svg-clock)
+- [Line/Area Chart](https://svelte.technology/repl?version=2&example=line-chart)
+- [Bar Chart](https://svelte.technology/repl?version=2&example=bar-chart)
+- [Scatterplot](https://svelte.technology/repl?version=2&example=scatterplot)
 
 #### Transitions (Experimental)
-- [Transition Directive](https://svelte.technology/repl?version=1&gist=f557e1b7cd55f9fffce86ce9677f8ae0)
+- [Fade](https://svelte.technology/repl?version=2&demo=transitions-fade)
+- 
 
 #### GUIs
-- [Counter](https://svelte.technology/repl?version=1&example=7guis-counter)
-- [Temperature Converter](https://svelte.technology/repl?version=1&example=7guis-temperature)
-- [Flight Booker](https://svelte.technology/repl?version=1&example=7guis-flight-booker)
-- [Timer](https://svelte.technology/repl?version=1&example=7guis-timer)
-- [CRUD](https://svelte.technology/repl?version=1&example=7guis-crud)
-- [Circles](https://svelte.technology/repl?version=1&example=7guis-circles)
+- [Counter](https://svelte.technology/repl?version=2&example=7guis-counter)
+- [Temperature Converter](https://svelte.technology/repl?version=2&example=7guis-temperature)
+- [Flight Booker](https://svelte.technology/repl?version=2&example=7guis-flight-booker)
+- [Timer](https://svelte.technology/repl?version=2&example=7guis-timer)
+- [CRUD](https://svelte.technology/repl?version=2&example=7guis-crud)
+- [Circles](https://svelte.technology/repl?version=2&example=7guis-circles)
 
 ### Apps
 - [Svelte HN](https://github.com/sveltejs/svelte-hackernews) - [An Hacker News clone](https://svelte-hn.now.sh) that _“is designed to test Svelte's ideas and see if there are any essential features that we're missing, and to act as an example for people looking to build their own Svelte apps.”_
@@ -152,9 +153,6 @@
   
 #### [SVG Support](https://twitter.com/sveltejs/status/839585697019363328)
   First-class SVG support, including SSR.
-
-#### [Media Elements Bindings](https://svelte.technology/repl?version=1&example=binding-media-elements)
-  Makes it easy to build custom controls for `<audio>` and `<video>`.
 
 #### [Deduplication](https://github.com/sveltejs/svelte/pull/215)
   [Allows](https://github.com/sveltejs/svelte/issues/9) [for](https://github.com/sveltejs/svelte/issues/203) 

--- a/readme.md
+++ b/readme.md
@@ -154,6 +154,9 @@
 #### [SVG Support](https://twitter.com/sveltejs/status/839585697019363328)
   First-class SVG support, including SSR.
 
+#### [Media Elements Bindings](https://svelte.technology/repl?version=2&demo=binding-media-elements)
+  Makes it easy to build custom controls for `<audio>` and `<video>`.
+
 #### [Deduplication](https://github.com/sveltejs/svelte/pull/215)
   [Allows](https://github.com/sveltejs/svelte/issues/9) [for](https://github.com/sveltejs/svelte/issues/203) 
   [non-standalone](https://github.com/sveltejs/svelte/issues/67) components to prevent duplication.


### PR DESCRIPTION
in Svelte v2 `{variable}` is now a thing but REPL's `?version=1` is expecting `{{variable}}`, so your linked examples don't work anymore.

I quickly changed some links to `version=2`, but seeing some examples don't exist anymore, & more were added, I'm wondering it would be more sane maintenance-wise not to directly link every example.  Instead link to the main demo page, & directly link 3-5 of the most interesting (eg complex) examples?

Untested most links due to suggested arch change.

By submitting this pull request, I promise I have read the [contribution guidelines](/../contributing.md) twice and ensured my submission follows it.